### PR TITLE
Fixed isue #2 removing visiblity modification in each render

### DIFF
--- a/mobile/src/main/java/butter/droid/adapters/MediaGridAdapter.java
+++ b/mobile/src/main/java/butter/droid/adapters/MediaGridAdapter.java
@@ -109,10 +109,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             videoViewHolder.title.setText(item.title);
             videoViewHolder.year.setText(item.year);
 
-            videoViewHolder.coverImage.setVisibility(View.GONE);
-            videoViewHolder.title.setVisibility(View.GONE);
-            videoViewHolder.year.setVisibility(View.GONE);
-
             if (item.image != null && !item.image.equals("")) {
                 Picasso.with(videoViewHolder.coverImage.getContext()).load(item.image)
                         .resize(mItemWidth, mItemHeight)


### PR DESCRIPTION
Removed setVisibility(View.GONE) in each view from onBindViewHolder method in MediaGridAdapter.java.

Modifying the visibility of the view in each render, the view flashes because when Picasso loads the images the view visibility changes again, so that's a flash on every scroll.