### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/connectsdk/CONTRIBUTING.md
+++ b/connectsdk/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#Contributing to Connect SDK
+# Contributing to Connect SDK
 
-##General Questions
+## General Questions
 
 Please do not use GitHub issues for general questions about the SDK. Instead, use any of the following services to reach out to the development team.
 
@@ -8,38 +8,38 @@ Please do not use GitHub issues for general questions about the SDK. Instead, us
 - Stack Overflow: [Connect-SDK tag](https://stackoverflow.com/tags/connect-sdk) (or [TV tag](https://stackoverflow.com/tags/tv))
 - [support@connectsdk.com](mailto:support@connectsdk.com)
 
-##Versioning
+## Versioning
 
 We use [semantic versioning](http://semver.org/) in our tagged releases.
 
-##Branching Strategy
+## Branching Strategy
 
 We use the [successful git branching model](http://nvie.com/posts/a-successful-git-branching-model/), except without release branches, and the `develop` branch is named `dev`.
 
-##Bug Reports & Feature Requests
+## Bug Reports & Feature Requests
 
 We use GitHub's issues system for managing bug reports and some upcoming features. Just open an issue and a member of the team will set the appropriate assignee, label, & milestone.
 
-###Crash Reports
+### Crash Reports
 
 If you experience a crash, please attach your symbolicated crash log or stack trace to an issue in GitHub.
 
-##Pull Requests
+## Pull Requests
 
 If you would like to submit code, please fork the repository on GitHub and develop in a feature branch, created from the latest `dev` commit. We do not accept pull requests on the `master` branch, as we only merge QA'd and tagged code into the `master` branch.
 
-###Tests
+### Tests
 
 Please include unit tests for the new/changed functionality with your pull request. It will help to verify the code is working as designed and make sure there are no regressions in future releases.
 
-###Use of third party libraries
+### Use of third party libraries
 
 Connect SDK includes some third party libraries. If you'd like to integrate a library with a pull request, make sure that library has an open source license (MIT, Apache 2.0, etc).
 
-###Licensing
+### Licensing
 
 If you submit a pull request, you acknowledge that your code will be released to the public under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html). Make sure that you have the rights to the code you are submitting in the pull request.
 
-##Testing Lab
+## Testing Lab
 
 In the development of Connect SDK, we have gathered a number of devices for testing purposes. If you are contributing to and/or integrating Connect SDK & would like something tested in our lab, you may contact [partners@connectsdk.com](mailto:partners@connectsdk.com) with your request.

--- a/connectsdk/README.md
+++ b/connectsdk/README.md
@@ -1,4 +1,4 @@
-#Connect SDK Android
+# Connect SDK Android
 Connect SDK is an open source framework that connects your mobile apps with multiple TV platforms. Because most TV platforms support a variety of protocols, Connect SDK integrates and abstracts the discovery and connectivity between all supported protocols.
 This project can be built in Android Studio or directly with Gradle. Eclipse IDE is not supported since 1.5.0 version.
 
@@ -8,7 +8,7 @@ For more information, visit our [website](http://www.connectsdk.com/).
 * [Platform documentation & FAQs](http://www.connectsdk.com/docs/android/)
 * [API documentation](http://www.connectsdk.com/apis/android/)
 
-##Dependencies
+## Dependencies
 This project has the following dependencies, some of which require manual setup. If you would like to use a version of the SDK which has no manual setup, consider using the [lite version](https://github.com/ConnectSDK/Connect-SDK-Android-Lite) of the SDK.
 
 This project has the following dependencies.
@@ -20,7 +20,7 @@ This project has the following dependencies.
 * [Connect-SDK-Android-FireTV](https://github.com/ConnectSDK/Connect-SDK-Android-FireTV) submodule
   - Requires [AmazonFling.framework](https://developer.amazon.com/public/apis/experience/fling/docs/amazon-fling-sdk-download)
 
-##Including Connect SDK in your app with Android Studio
+## Including Connect SDK in your app with Android Studio
 Edit your project's build.gradle to add this in the "dependencies" section
 ```groovy
 dependencies {
@@ -31,7 +31,7 @@ dependencies {
 This prebuilt library doesn't have Amazon Fling SDK support, because it’s not available on maven. You need to set the project up from sources
 if you want to have Amazon Fling SDK support.
 
-##Including Connect SDK in your app with Android Studio from sources
+## Including Connect SDK in your app with Android Studio from sources
 1. Open your terminal and execute these commands
     ```
     cd your_project_folder
@@ -57,7 +57,7 @@ if you want to have Amazon Fling SDK support.
 5. Sync project with gradle files
 6. Add permissions to your manifest
 
-###Permissions to include in manifest
+### Permissions to include in manifest
 * Required for SSDP & Chromecast/Zeroconf discovery
  - `android.permission.INTERNET`
  - `android.permission.CHANGE_WIFI_MULTICAST_STATE`
@@ -75,7 +75,7 @@ if you want to have Amazon Fling SDK support.
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
-###Metadata for application tag
+### Metadata for application tag
 This metadata tag is necessary to enable Chromecast support.
 
 ```xml
@@ -89,14 +89,14 @@ This metadata tag is necessary to enable Chromecast support.
 </application>
 ```
 
-###Proguard configuration
+### Proguard configuration
 Add the following line to your proguard configuration file (otherwise `DiscoveryManager` won't be able to set any `DiscoveryProvider`).
 
 ```
 -keep class com.connectsdk.**       { * ; }
 ```
 
-###Tests
+### Tests
 Connect SDK has unit tests for some parts of the code, and we are continuing to increase the test coverage.
 These tests are based on third party libraries such as Robolectric, Mockito and PowerMock. You can easily run these tests with Gradle:
 ```
@@ -108,14 +108,14 @@ gradle jacocoTestReport
 ```
 The test coverage report will be in this folder `Connect-SDK-Android/build/reports/jacoco/jacocoTestReport/html`.
 
-##Contact
+## Contact
 * Twitter [@ConnectSDK](https://www.twitter.com/ConnectSDK)
 * Ask a question on Stack Overflow with the [Connect-SDK tag](https://stackoverflow.com/tags/connect-sdk) (or [TV tag](https://stackoverflow.com/tags/tv))
 * General Inquiries info@connectsdk.com
 * Developer Support support@connectsdk.com
 * Partnerships partners@connectsdk.com
 
-##Credits
+## Credits
 Connect SDK for Android makes use of the following projects, some of which are open-source.
 
 * [Amazon Fling SDK](https://developer.amazon.com/fling)
@@ -132,7 +132,7 @@ These projects are used in tests:
 * [Robolectric](http://robolectric.org) (MIT)
 * [PowerMock](https://github.com/jayway/powermock) (Apache License, Version 2.0)
 
-##License
+## License
 Copyright (c) 2013-2015 LG Electronics.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/connectsdk/core/README.md
+++ b/connectsdk/core/README.md
@@ -1,4 +1,4 @@
-#Connect SDK Core (Android)
+# Connect SDK Core (Android)
 The Connect SDK Core contains all of the core classes required for basic operation of Connect SDK. The core also includes support for some select protocols which do not have any heavy and/or external dependencies. These protocols include:
 - Apple TV
 - DIAL
@@ -7,13 +7,13 @@ The Connect SDK Core contains all of the core classes required for basic operati
 - LG webOS
 - Roku
 
-##General Information
+## General Information
 For more information about Connect SDK, visit the [main repository](https://github.com/ConnectSDK/Connect-SDK-Android).
 
-##Setup
+## Setup
 Unless you are doing very specialized work to extend the SDK, you should not need to make direct use of this repository. Instead, clone the [main repository](https://github.com/ConnectSDK/Connect-SDK-Android), which includes this repository as a submodule.
 
-##License
+## License
 Copyright (c) 2013-2015 LG Electronics.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/connectsdk/modules/firetv/README.md
+++ b/connectsdk/modules/firetv/README.md
@@ -7,11 +7,11 @@ following functionality:
     * Media control
 Using Connect SDK for discovery/control of Fire TV devices will result in your app complying with the [Amazon Fling SDK terms of service](https://developer.amazon.com/public/support/pml.html).
 
-##General Information
+## General Information
 For more information about Connect SDK, visit the [main repository](https://github.com/ConnectSDK/Connect-SDK-Android). This project can be built in Android Studio or directly with Gradle. Eclipse IDE is not supported.
 
-##Setup
-###Connect SDK Integration
+## Setup
+### Connect SDK Integration
 1. Setup [Connect-SDK-Android](https://github.com/ConnectSDK/Connect-SDK-Android)
 2. Download AmazonFling.jar and WhisperPlay.jar from [the Amazon website](https://developer.amazon.com/public/apis/experience/fling/docs/amazon-fling-sdk-download) and put them into ```Connect-SDK-Android/modules/firetv/libs/``` folder
 3. Add these lines into dependency section of build.gradle file:
@@ -22,7 +22,7 @@ For more information about Connect SDK, visit the [main repository](https://gith
     ```
 4. Synchronize your project with Gradle files
 
-###Connect SDK Lite Integration
+### Connect SDK Lite Integration
 1. Setup [Connect-SDK-Android-Lite](https://github.com/ConnectSDK/Connect-SDK-Android-Lite)
 2. Clone this repository into a subfolder of the Connect SDK Lite project (e.g. modules/firetv)
 3. Go to the [Amazon Developer site](https://developer.amazon.com/) download the AmazonFling.jar and WhisperPlay.jar and put them into ```Connect-SDK-Android/modules/firetv/libs/``` folder
@@ -64,7 +64,7 @@ For more information about Connect SDK, visit the [main repository](https://gith
     inside `getDeviceServiceMap()` method.
 
 
-##License
+## License
 Copyright (c) 2015 LG Electronics.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/connectsdk/modules/google_cast/README.md
+++ b/connectsdk/modules/google_cast/README.md
@@ -1,14 +1,14 @@
-#Google Cast module for Connect SDK (Android)
+# Google Cast module for Connect SDK (Android)
 The Google Cast module extends Connect SDK to add Google Cast SDK support. This repository is included as a submodule in the main project, and has some manual setup before the main project will compile.
 
-##General Information
+## General Information
 For more information about Connect SDK, visit the [main repository](https://github.com/ConnectSDK/Connect-SDK-Android).
 
-##Setup
-###Connect SDK Integration
+## Setup
+### Connect SDK Integration
 It's already integrated in Connect-SDK-Android. Set it up following the instructions for Connect-SDK-Android.
 
-###Connect SDK Lite Integration
+### Connect SDK Lite Integration
 1. Setup [Connect-SDK-Android-Lite](https://github.com/ConnectSDK/Connect-SDK-Android-Lite)
 2. Clone this repository into a subfolder of the Connect SDK Lite project (e.g. `modules/google_cast`)
 3. Add sources files for Google Cast module in your `build.gradle`, it should looks similar to this (here we have Google Cast module in `modules/google_cast` folder):
@@ -42,7 +42,7 @@ It's already integrated in Connect-SDK-Android. Set it up following the instruct
     ```
     inside `getDeviceServiceMap()` method.
 
-##License
+## License
 Copyright (c) 2013-2015 LG Electronics.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
