### PR TITLE
Performance updates

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -44,9 +44,9 @@ dependencies {
     api "com.android.support:design:$appCompatVersion"
 
     debugImplementation 'com.github.simonpercic:oklog3:2.2.0'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
 
-    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
 
     api 'com.jakewharton.timber:timber:4.5.1'
     api "com.squareup.okhttp3:okhttp:$okHttpVersion"

--- a/base/src/main/java/butter/droid/base/ui/loading/fragment/BaseStreamLoadingFragmentPresenterImpl.java
+++ b/base/src/main/java/butter/droid/base/ui/loading/fragment/BaseStreamLoadingFragmentPresenterImpl.java
@@ -31,8 +31,6 @@ import butter.droid.base.utils.ThreadUtils;
 import com.github.se_bastiaan.torrentstream.StreamStatus;
 import com.github.se_bastiaan.torrentstream.Torrent;
 import com.github.se_bastiaan.torrentstream.listeners.TorrentListener;
-import java.text.DecimalFormat;
-import java.util.Locale;
 
 public abstract class BaseStreamLoadingFragmentPresenterImpl implements BaseStreamLoadingFragmentPresenter,
         TorrentListener {
@@ -186,7 +184,6 @@ public abstract class BaseStreamLoadingFragmentPresenterImpl implements BaseStre
     /**
      * Update the view based on a state.
      *
-     * @param state
      * @param extra - an optional extra piece of data relating to the state, such as an error message, or status data
      */
     protected void updateView(State state, Object extra) {
@@ -267,28 +264,27 @@ public abstract class BaseStreamLoadingFragmentPresenterImpl implements BaseStre
     }
 
     private void updateStatus(final StreamStatus status) {
-        final DecimalFormat df = new DecimalFormat("#############0.00");
-        ThreadUtils.runOnUiThread(() -> {
-            int progress;
-            if (!playingExternal) {
-                progress = status.bufferProgress;
-            } else {
-                progress = ((Float) status.progress).intValue();
-            }
+        int progress;
+        if (!playingExternal) {
+            progress = status.bufferProgress;
+        } else {
+            progress = ((Float) status.progress).intValue();
+        }
 
-            String progressText = String.format(Locale.US, "%d%%", progress);
+        String progressText = progress + "%";
 
-            String speedText;
-            if (status.downloadSpeed / 1024 < 1000) {
-                speedText = df.format(status.downloadSpeed / 1024) + " KB/s";
-            } else {
-                speedText = df.format(status.downloadSpeed / 1048576) + " MB/s";
-            }
+        String speedText;
+        if (status.downloadSpeed / 1024 < 1000) {
+            int i = (int) (status.downloadSpeed / 102.4);
+            speedText = i / 10 + "." + i % 10 + " KB/s";
+        } else {
+            int i = (int) (status.downloadSpeed / 104857.6);
+            speedText = i / 10 + "." + i % 10 + " MB/s";
+        }
 
-            String seedsText = status.seeds + " " + context.getString(R.string.seeds);
+        String seedsText = status.seeds + " " + context.getString(R.string.seeds);
 
-            view.displayDetails(progress, progressText, speedText, seedsText);
-        });
+        view.displayDetails(progress, progressText, speedText, seedsText);
     }
 
 }

--- a/base/src/main/java/butter/droid/base/utils/StringUtils.java
+++ b/base/src/main/java/butter/droid/base/utils/StringUtils.java
@@ -45,6 +45,12 @@ import java.util.Locale;
 
 public class StringUtils {
 
+    private static final DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+
+    static {
+        formatter.applyPattern("00");
+    }
+
     /**
      * Convert time to a string
      *
@@ -63,12 +69,10 @@ public class StringUtils {
         int hours = (int) millis;
 
         String time;
-        DecimalFormat format = (DecimalFormat) NumberFormat.getInstance(Locale.US);
-        format.applyPattern("00");
         if (millis > 0) {
-            time = (negative ? "-" : "") + hours + ":" + format.format(min) + ":" + format.format(sec);
+            time = (negative ? "-" : "") + hours + ":" + formatter.format(min) + ":" + formatter.format(sec);
         } else {
-            time = (negative ? "-" : "") + min + ":" + format.format(sec);
+            time = (negative ? "-" : "") + min + ":" + formatter.format(sec);
         }
 
         return time;

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlinVersion = '1.1.51'
+        kotlinVersion = '1.1.60'
     }
 
     repositories {
@@ -16,14 +16,14 @@ buildscript {
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath "gradle.plugin.si.kamino.gradle:android-version:1.3.2"
+        classpath "gradle.plugin.si.kamino.gradle:android-version:1.4.0"
         classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
 ext {
-    appCompatVersion = "27.0.0"
+    appCompatVersion = "27.0.1"
     buildToolsVersion = "26.0.2"
     targetSdk = 26
     compileSdk = 26


### PR DESCRIPTION
After doing some analysis I noticed that over 50% of CPU time was wasted on number formatting for displaying progress and download speed on UI. This minor updates will make things much faster and improve performance of the app.

Along with VLC update done in few releases back video playing us much smoother. One thing that is still missing is to show progress bar when when video is not being downloaded fast enough. That should be handled with #142.

This update should make things better for errors like popcorn-official/popcorn-android#295, popcorn-official/popcorn-android#284, ... when it makes it to popcorn.